### PR TITLE
Bugfix and overrides

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,11 @@ python:
 sudo: false
 os:
   - linux
-env:
-  - TOX_ENV=lint
-  - TOX_ENV=py27
-  - TOX_ENV=py36
 
 install:
-  - pip install tox
+  - pip install -r test-requirements.txt -r requirements.txt
 
 script:
-  - tox -e $TOX_ENV
+  - flake8 --config ./lint-configs/python/.flake8 st2auth_enterprise_ldap_backend/
+  - pylint -E --rcfile=./lint-configs/python/.pylintrc st2auth_enterprise_ldap_backend/
+  - nosetests -sv --with-coverage --cover-package=st2auth_enterprise_ldap_backend tests/unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: python
-python: 2.7
+python:
+  - "2.7"
+  - "3.6"
 sudo: false
 os:
   - linux
 env:
   - TOX_ENV=lint
   - TOX_ENV=py27
+  - TOX_ENV=py36
 
 install:
   - pip install tox

--- a/README.md
+++ b/README.md
@@ -16,26 +16,26 @@ sudo dnf install python2-devel python3-devel openldap-devel
 
 ## Configuration Options
 
-| option                     | required | default | description                                                                                                                    |
-|----------------------------|----------|---------|--------------------------------------------------------------------------------------------------------------------------------|
-| bind_dn                    | yes      |         | DN of the service account to bind with the LDAP server                                                                         |
-| bind_password              | yes      |         | Password of the service account                                                                                                |
-| base_ou                    | yes      |         | Base OU to search for user and group entries                                                                                   |
-| group_dns                  | yes      |         | Which groups user must be member of to be granted access                                                                       |
-| group_dns_check            | no       | and     | What kind of check to perform when validating user group membership (`and` / `or`). When `and` behavior is used, user needs to be part of all the specified groups and when `or` behavior is used, user needs to be part of at least one or more of the specified groups.                                                         |
-| host                       | yes      |         | Hostname of the LDAP server                                                                                                    |
-| port                       | yes      |         | Port of the LDAP server                                                                                                        |
-| use_ssl                    | no       | false   | Use LDAPS to connect                                                                                                           |
-| use_tls                    | no       | false   | Start TLS on LDAP to connect                                                                                                   |
-| cacert                     | no       | None    | Path to the CA cert used to validate certificate                                                                               |
-| id_attr                    | no       | uid     | Field name of the user ID attribute                                                                                            |
-| scope                      | no       | subtree | Search scope (base, onelevel, or subtree)                                                                                      |
-| network_timeout            | no       | 10.0    | Timeout for network operations (in seconds)                                                                                    |
-| chase_referrals            | no       | false   | True if the referrals should be automatically chased within the underlying LDAP C lib                                          |
-| debug                      | no       | false   | Enable debug mode. When debug mode is enabled all the calls (including the results) to LDAP server are logged                  |
-| client_options             | no       |         | A dictionary with additional Python LDAP client options which can be passed to `set_connection()` method                     |
-| cache_user_groups_response | no       | true    | When true, LDAP user groups response is cached for 120 seconds (by default) in memory. This decreases load on LDAP server and increases performance when remote LDAP group to RBAC role sync is enabled and / or when the same user authenticates concurrency in a short time frame. Keep in mind that even when this feature is enabled, single (authenticate) request to LDAP server will still be performed when user authenticates to st2auth - authentication information is not cached - only user groups are cached.  |
-| cache_user_groups_ttl      | no       | 120     | How long (in seconds)                                                                                                          |
+| option                     | required |  default  | description                                                                                                                    |
+|----------------------------|----------|-----------|--------------------------------------------------------------------------------------------------------------------------------|
+| bind_dn                    | yes      |           | DN of the service account to bind with the LDAP server                                                                         |
+| bind_password              | yes      |           | Password of the service account                                                                                                |
+| base_ou                    | yes      |           | Base OU to search for user and group entries                                                                                   |
+| group_dns                  | yes      |           | Which groups user must be member of to be granted access                                                                       |
+| group_dns_check            | no       | `and`     | What kind of check to perform when validating user group membership (`and` / `or`). When `and` behavior is used, user needs to be part of all the specified groups and when `or` behavior is used, user needs to be part of at least one or more of the specified groups.                                                         |
+| host                       | yes      |           | Hostname of the LDAP server                                                                                                    |
+| port                       | yes      |           | Port of the LDAP server                                                                                                        |
+| use_ssl                    | no       | `false`   | Use LDAPS to connect                                                                                                           |
+| use_tls                    | no       | `false`   | Start TLS on LDAP to connect                                                                                                   |
+| cacert                     | no       | `None`    | Path to the CA cert used to validate certificate                                                                               |
+| id_attr                    | no       | `uid`     | Field name of the user ID attribute                                                                                            |
+| scope                      | no       | `subtree` | Search scope (base, onelevel, or subtree)                                                                                      |
+| network_timeout            | no       | `10.0`    | Timeout for network operations (in seconds)                                                                                    |
+| chase_referrals            | no       | `false`   | True if the referrals should be automatically chased within the underlying LDAP C lib                                          |
+| debug                      | no       | `false`   | Enable debug mode. When debug mode is enabled all the calls (including the results) to LDAP server are logged                  |
+| client_options             | no       |           | A dictionary with additional Python LDAP client options which can be passed to `set_connection()` method                     |
+| cache_user_groups_response | no       | `true`    | When true, LDAP user groups response is cached for 120 seconds (by default) in memory. This decreases load on LDAP server and increases performance when remote LDAP group to RBAC role sync is enabled and / or when the same user authenticates concurrency in a short time frame. Keep in mind that even when this feature is enabled, single (authenticate) request to LDAP server will still be performed when user authenticates to st2auth - authentication information is not cached - only user groups are cached.  |
+| cache_user_groups_ttl      | no       | `120`     | How long (in seconds)                                                                                                          |
 
 ## Configuration Example
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ sudo dnf install python2-devel python3-devel openldap-devel
 | bind_password              | yes      |         | Password of the service account                                                                                                |
 | base_ou                    | yes      |         | Base OU to search for user and group entries                                                                                   |
 | group_dns                  | yes      |         | Which groups user must be member of to be granted access                                                                       |
-| group_dns_check            | no       | and     | What kind of check to perform when validating user group membership (``and`` / ``or``). When ``and`` behavior is used, user needs to be part of all the specified groups and when ``or`` behavior is used, user needs to be part of at least one or more of the specified groups.                                                         |
+| group_dns_check            | no       | and     | What kind of check to perform when validating user group membership (`and` / `or`). When `and` behavior is used, user needs to be part of all the specified groups and when `or` behavior is used, user needs to be part of at least one or more of the specified groups.                                                         |
 | host                       | yes      |         | Hostname of the LDAP server                                                                                                    |
 | port                       | yes      |         | Port of the LDAP server                                                                                                        |
 | use_ssl                    | no       | false   | Use LDAPS to connect                                                                                                           |
@@ -33,7 +33,7 @@ sudo dnf install python2-devel python3-devel openldap-devel
 | network_timeout            | no       | 10.0    | Timeout for network operations (in seconds)                                                                                    |
 | chase_referrals            | no       | false   | True if the referrals should be automatically chased within the underlying LDAP C lib                                          |
 | debug                      | no       | false   | Enable debug mode. When debug mode is enabled all the calls (including the results) to LDAP server are logged                  |
-| client_options             | no       |         | A dictionary with additional Python LDAP client options which can be passed to ``set_connection()`` method                     |
+| client_options             | no       |         | A dictionary with additional Python LDAP client options which can be passed to `set_connection()` method                     |
 | cache_user_groups_response | no       | true    | When true, LDAP user groups response is cached for 120 seconds (by default) in memory. This decreases load on LDAP server and increases performance when remote LDAP group to RBAC role sync is enabled and / or when the same user authenticates concurrency in a short time frame. Keep in mind that even when this feature is enabled, single (authenticate) request to LDAP server will still be performed when user authenticates to st2auth - authentication information is not cached - only user groups are cached.  |
 | cache_user_groups_ttl      | no       | 120     | How long (in seconds)                                                                                                          |
 
@@ -55,7 +55,7 @@ logging = /path/to/st2auth.logging.conf
 api_url = http://myhost.example.com:9101/
 ```
 
-Note: Key in the ``client_options`` dictionary must be an integer representing a LDAP constant option value.
+Note: Key in the `client_options` dictionary must be an integer representing a LDAP constant option value.
 
 For example:
 
@@ -63,7 +63,7 @@ For example:
 backend_kwargs = {..., "client_options": {"20482": 9}}
 ```
 
-In this case, "20482" represents ``ldap.OPT_TIMEOUT`` option.
+In this case, "20482" represents `ldap.OPT_TIMEOUT` option.
 
 To retrieve a integer value of a particular client option constant, you can run the following code:
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ sudo dnf install python2-devel python3-devel openldap-devel
 | bind_dn                    | yes      |                | DN of the service account to bind with the LDAP server                                                                         |
 | bind_password              | yes      |                | Password of the service account                                                                                                |
 | base_ou                    | yes      |                | Base OU to search for user and group entries                                                                                   |
-| group_dns                  | yes      |                | Which groups user must be member of to be granted access                                                                       |
+| group_dns                  | yes      |                | Which groups user must be member of to be granted access (group names are considered case-insensitive)                         |
 | group_dns_check            | no       | `and`          | What kind of check to perform when validating user group membership (`and` / `or`). When `and` behavior is used, user needs to be part of all the specified groups and when `or` behavior is used, user needs to be part of at least one or more of the specified groups. |
 | host                       | yes      |                | Hostname of the LDAP server                                                                                                    |
 | port                       | yes      |                | Port of the LDAP server                                                                                                        |

--- a/README.md
+++ b/README.md
@@ -16,26 +16,26 @@ sudo dnf install python2-devel python3-devel openldap-devel
 
 ## Configuration Options
 
-| option                     | required |  default  | description                                                                                                                    |
-|----------------------------|----------|-----------|--------------------------------------------------------------------------------------------------------------------------------|
-| bind_dn                    | yes      |           | DN of the service account to bind with the LDAP server                                                                         |
-| bind_password              | yes      |           | Password of the service account                                                                                                |
-| base_ou                    | yes      |           | Base OU to search for user and group entries                                                                                   |
-| group_dns                  | yes      |           | Which groups user must be member of to be granted access                                                                       |
-| group_dns_check            | no       | `and`     | What kind of check to perform when validating user group membership (`and` / `or`). When `and` behavior is used, user needs to be part of all the specified groups and when `or` behavior is used, user needs to be part of at least one or more of the specified groups.                                                         |
-| host                       | yes      |           | Hostname of the LDAP server                                                                                                    |
-| port                       | yes      |           | Port of the LDAP server                                                                                                        |
-| use_ssl                    | no       | `false`   | Use LDAPS to connect                                                                                                           |
-| use_tls                    | no       | `false`   | Start TLS on LDAP to connect                                                                                                   |
-| cacert                     | no       | `None`    | Path to the CA cert used to validate certificate                                                                               |
-| id_attr                    | no       | `uid`     | Field name of the user ID attribute                                                                                            |
-| scope                      | no       | `subtree` | Search scope (base, onelevel, or subtree)                                                                                      |
-| network_timeout            | no       | `10.0`    | Timeout for network operations (in seconds)                                                                                    |
-| chase_referrals            | no       | `false`   | True if the referrals should be automatically chased within the underlying LDAP C lib                                          |
-| debug                      | no       | `false`   | Enable debug mode. When debug mode is enabled all the calls (including the results) to LDAP server are logged                  |
-| client_options             | no       |           | A dictionary with additional Python LDAP client options which can be passed to `set_connection()` method                     |
-| cache_user_groups_response | no       | `true`    | When true, LDAP user groups response is cached for 120 seconds (by default) in memory. This decreases load on LDAP server and increases performance when remote LDAP group to RBAC role sync is enabled and / or when the same user authenticates concurrency in a short time frame. Keep in mind that even when this feature is enabled, single (authenticate) request to LDAP server will still be performed when user authenticates to st2auth - authentication information is not cached - only user groups are cached.  |
-| cache_user_groups_ttl      | no       | `120`     | How long (in seconds)                                                                                                          |
+| option                     | required |     default    | description                                                                                                                    |
+|----------------------------|----------|----------------|--------------------------------------------------------------------------------------------------------------------------------|
+| bind_dn                    | yes      |                | DN of the service account to bind with the LDAP server                                                                         |
+| bind_password              | yes      |                | Password of the service account                                                                                                |
+| base_ou                    | yes      |                | Base OU to search for user and group entries                                                                                   |
+| group_dns                  | yes      |                | Which groups user must be member of to be granted access                                                                       |
+| group_dns_check            | no       | `and`          | What kind of check to perform when validating user group membership (`and` / `or`). When `and` behavior is used, user needs to be part of all the specified groups and when `or` behavior is used, user needs to be part of at least one or more of the specified groups. |
+| host                       | yes      |                | Hostname of the LDAP server                                                                                                    |
+| port                       | yes      |                | Port of the LDAP server                                                                                                        |
+| use_ssl                    | no       | `false`        | Use LDAPS to connect                                                                                                           |
+| use_tls                    | no       | `false`        | Start TLS on LDAP to connect                                                                                                   |
+| cacert                     | no       | `None`         | Path to the CA cert used to validate certificate                                                                               |
+| id_attr                    | no       | `uid`          | Field name of the user ID attribute                                                                                            |
+| scope                      | no       | `subtree`      | Search scope (base, onelevel, or subtree)                                                                                      |
+| network_timeout            | no       | `10.0`         | Timeout for network operations (in seconds)                                                                                    |
+| chase_referrals            | no       | `false`        | True if the referrals should be automatically chased within the underlying LDAP C lib                                          |
+| debug                      | no       | `false`        | Enable debug mode. When debug mode is enabled all the calls (including the results) to LDAP server are logged                  |
+| client_options             | no       |                | A dictionary with additional Python LDAP client options which can be passed to `set_connection()` method                       |
+| cache_user_groups_response | no       | `true`         | When true, LDAP user groups response is cached for 120 seconds (by default) in memory. This decreases load on LDAP server and increases performance when remote LDAP group to RBAC role sync is enabled and / or when the same user authenticates concurrency in a short time frame. Keep in mind that even when this feature is enabled, single (authenticate) request to LDAP server will still be performed when user authenticates to st2auth - authentication information is not cached - only user groups are cached. |
+| cache_user_groups_ttl      | no       | `120`          | How long (in seconds)                                                                                                          |
 
 ## Configuration Example
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ sudo dnf install python2-devel python3-devel openldap-devel
 | use_ssl                    | no       | `false`        | Use LDAPS to connect                                                                                                           |
 | use_tls                    | no       | `false`        | Start TLS on LDAP to connect                                                                                                   |
 | cacert                     | no       | `None`         | Path to the CA cert used to validate certificate                                                                               |
-| id_attr                    | no       | `uid`          | Field name of the user ID attribute                                                                                            |
+| id_attr                    | no       | `uid`          | Field name of the user ID attribute; ignored if `account_pattern` is specified.                                                |
+| account_pattern            | no       | `{id_attr}={{username}}` | LDAP subtree pattern to match user. The user's `username` is escaped and interpolated into this string (see example).     |
+| group_pattern              | no       | `(|(&(objectClass=*)(|(member={user_dn})(uniqueMember={user_dn})(memberUid={username}))))` | LDAP subtree pattern for user groups. Both `user_dn` and `username` are escaped and then interpolated into this string (see example).  |
 | scope                      | no       | `subtree`      | Search scope (base, onelevel, or subtree)                                                                                      |
 | network_timeout            | no       | `10.0`         | Timeout for network operations (in seconds)                                                                                    |
 | chase_referrals            | no       | `false`        | True if the referrals should be automatically chased within the underlying LDAP C lib                                          |
@@ -48,7 +50,9 @@ The LDAP backend attempts a few different LDAP operations to authenticate users 
 
 If all of the steps succeed, then the user is authenticated. If any of those steps fail, then the authentication fails.
 
-## Configuration Example
+## Configuration Examples
+
+### Simple Configuration
 
 Please refer to the [standalone mode](http://docs.stackstorm.com/config/authentication.html#setup-standalone-mode) in the configuration section for authentication for basic setup concept. The following is an example of the auth section in the StackStorm configuration file for the LDAP backend.
 
@@ -82,6 +86,81 @@ To retrieve a integer value of a particular client option constant, you can run 
 import ldap
 print(ldap.OPT_TIMEOUT)
 ```
+
+Additionally, this simple example uses the default values for the `id_attr`, `account_pattern`, and `group_pattern` configuration options. This means that the user's account will be queried with the default LDAP search pattern `uid={username}`, and the groups will be queried with the default LDAP search pattern `(|(&(objectClass=*)(|(member={user_dn})(uniqueMember={user_dn})(memberUid={username}))))`.
+
+### Configuration Specifying `id_attr`
+
+If your LDAP server uses a different name for the user ID attribute, you can simply specify the `id_attr` configuration option.
+
+```ini
+[auth]
+mode = standalone
+backend = ldap
+backend_kwargs = {"bind_dn": "CN=st2admin,ou=users,dc=example,dc=com", "bind_password": "foobar123", "base_ou": "dc=example,dc=com", "id_attr": "username", "group_dns": ["CN=st2users,ou=groups,dc=example,dc=com", "CN=st2developers,ou=groups,dc=example,dc=com"], "host": "identity.example.com", "port": 636, "use_ssl": true, "cacert": "/path/to/cacert.pem"}
+enable = True
+debug = False
+use_ssl = True
+cert = /path/to/mycert.crt
+key = /path/to/mycert.key
+logging = /path/to/st2auth.logging.conf
+api_url = http://myhost.example.com:9101/
+```
+
+#### Explanation
+
+In this example, the user's account will be queried with the LDAP search pattern `username={username}`, and the user's groups will be queried with the default LDAP search pattern from above.
+
+### Configuration Overriding `account_pattern` and `group_pattern`
+
+```ini
+[auth]
+mode = standalone
+backend = ldap
+backend_kwargs = {"bind_dn": "CN=st2admin,ou=users,dc=example,dc=com", "bind_password": "foobar123", "base_ou": "dc=example,dc=com", "account_pattern": "(&(objectClass=person)(|(accountName={username})(mail={username})))", "group_pattern": "(&(objectClass=userGroup)(|(member={user_dn})(uniqueMember={user_dn})(memberUsername={username})))", "group_dns": ["CN=st2users,ou=groups,dc=example,dc=com", "CN=st2developers,ou=groups,dc=example,dc=com"], "host": "identity.example.com", "port": 636, "use_ssl": true, "cacert": "/path/to/cacert.pem"}
+enable = True
+debug = False
+use_ssl = True
+cert = /path/to/mycert.crt
+key = /path/to/mycert.key
+logging = /path/to/st2auth.logging.conf
+api_url = http://myhost.example.com:9101/
+```
+
+Note: You do not have to override both `account_pattern` and `group_pattern` together, you may only need to override one of them.
+
+#### Explanation
+
+It's easier to read the `account_pattern` string `(&(objectClass=person)(|(accountName={username})(mail={username})))` if it is reformatted to show the nesting:
+
+```
+(&
+  (objectClass=person)
+  (|
+    (accountName={username})
+    (mail={username})
+  )
+)
+```
+
+The Python string format patterns `{username}` will be interpolated with the LDAP username of users who are authenticating with StackStorm. This means that the `account_pattern` search string will query the LDAP server for a user who has the LDAP `objectClass` attribute equal to `person` **and** whose LDAP `accountName` **or** LDAP `mail` attributes are equal to the username they submit to StackStorm.
+
+For `group_pattern`, the usage is similar, but it has an additional `user_dn` variable that will be interpolated into the string:
+
+```
+(&
+  (objectClass=userGroup)
+  (|
+    (member={user_dn})
+    (uniqueMember={user_dn})
+    (memberUsername={username})
+  )
+)
+```
+
+This search string will query for LDAP objects that have `objectClass` attributes equal to `userGroup` **and** whose LDAP `member` **or** `uniqueMember` attributes are equal to the user's LDAP `user_dn` value **or** whose LDAP `memberUsername` attributes are equal to the username they submit to StackStorm.
+
+The `user_dn` value is the user's `bind_dn` attribute returned by the LDAP server in step 2.
 
 ## Running tests
 

--- a/dist_utils.py
+++ b/dist_utils.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2020 Extreme Networks, Inc - All Rights Reserved
+# NOTE: This file is auto-generated - DO NOT EDIT MANUALLY
+#       Instead modify scripts/dist_utils.py and run 'make .sdist-requirements' to
+#       update dist_utils.py files for all components
+
+# Copyright 2019 Extreme Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,31 +25,29 @@ import sys
 
 from distutils.version import StrictVersion
 
+# NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
+#
+# TODO: Why can't this script rely on 3rd party dependencies? Is it because it has to import
+#       from pip?
+#
+# TODO: Dear future developer, if you are back here fixing a bug with how we parse
+#       requirements files, please look into using the packaging package on PyPI:
+#       https://packaging.pypa.io/en/latest/requirements/
+#       and specifying that in the `setup_requires` argument to `setuptools.setup()`
+#       for subpackages.
+#       At the very least we can vendorize some of their code instead of reimplementing
+#       each piece of their code every time our parsing breaks.
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    text_type = str
+else:
+    text_type = unicode  # NOQA
+
 GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
-try:
-    import pip
-    from pip import __version__ as pip_version
-except ImportError as e:
-    print('Failed to import pip: %s' % (str(e)))
-    print('')
-    print('Download pip:\n%s' % (GET_PIP))
-    sys.exit(1)
-
-try:
-    # pip < 10.0
-    from pip.req import parse_requirements
-except ImportError:
-    # pip >= 10.0
-
-    try:
-        from pip._internal.req.req_file import parse_requirements
-    except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (str(e)))
-        print('Using pip: %s' % (str(pip_version)))
-        sys.exit(1)
-
 __all__ = [
+    'check_pip_is_installed',
     'check_pip_version',
     'fetch_requirements',
     'apply_vagrant_workaround',
@@ -54,16 +56,37 @@ __all__ = [
 ]
 
 
+def check_pip_is_installed():
+    """
+    Ensure that pip is installed.
+    """
+    try:
+        import pip  # NOQA
+    except ImportError as e:
+        print('Failed to import pip: %s' % (text_type(e)))
+        print('')
+        print('Download pip:\n%s' % (GET_PIP))
+        sys.exit(1)
+
+    return True
+
+
 def check_pip_version(min_version='6.0.0'):
     """
     Ensure that a minimum supported version of pip is installed.
     """
+    check_pip_is_installed()
+
+    import pip
+
     if StrictVersion(pip.__version__) < StrictVersion(min_version):
         print("Upgrade pip, your version '{0}' "
               "is outdated. Minimum required version is '{1}':\n{2}".format(pip.__version__,
                                                                             min_version,
                                                                             GET_PIP))
         sys.exit(1)
+
+    return True
 
 
 def fetch_requirements(requirements_file_path):
@@ -72,12 +95,46 @@ def fetch_requirements(requirements_file_path):
     """
     links = []
     reqs = []
-    for req in parse_requirements(requirements_file_path, session=False):
-        # Note: req.url was used before 9.0.0 and req.link is used in all the recent versions
-        link = getattr(req, 'link', getattr(req, 'url', None))
-        if link:
-            links.append(str(link))
-        reqs.append(str(req.req))
+
+    def _get_link(line):
+        vcs_prefixes = ['git+', 'svn+', 'hg+', 'bzr+']
+
+        for vcs_prefix in vcs_prefixes:
+            if line.startswith(vcs_prefix) or line.startswith('-e %s' % (vcs_prefix)):
+                req_name = re.findall('.*#egg=(.+)([&|@]).*$', line)
+
+                if not req_name:
+                    req_name = re.findall('.*#egg=(.+?)$', line)
+                else:
+                    req_name = req_name[0]
+
+                if not req_name:
+                    raise ValueError('Line "%s" is missing "#egg=<package name>"' % (line))
+
+                link = line.replace('-e ', '').strip()
+                return link, req_name[0]
+
+        return None, None
+
+    with open(requirements_file_path, 'r') as fp:
+        for line in fp.readlines():
+            line = line.strip()
+
+            if line.startswith('#') or not line:
+                continue
+
+            link, req_name = _get_link(line=line)
+
+            if link:
+                links.append(link)
+            else:
+                req_name = line
+
+                if ';' in req_name:
+                    req_name = req_name.split(';')[0].strip()
+
+            reqs.append(req_name)
+
     return (reqs, links)
 
 

--- a/st2auth_enterprise_ldap_backend/ldap_backend.py
+++ b/st2auth_enterprise_ldap_backend/ldap_backend.py
@@ -51,7 +51,7 @@ VALID_GROUP_DNS_CHECK_VALUES = [
 # Note: To avoid injection attacks the final query needs to be assembled ldap.filter.filter_format
 # method and *NOT* by doing simple string formating / concatenation (method ensures filter values
 # are correctly escaped).
-USER_GROUP_MEMBERSHIP_QUERY = '(|(&(objectClass=*)(|(member={user_dn})(uniqueMember={user_dn})(memberUid={username}))))'
+USER_GROUP_MEMBERSHIP_QUERY = '(|(&(objectClass=*)(|(member={user_dn})(uniqueMember={user_dn})(memberUid={username}))))'  # noqa: E501
 
 
 class LDAPAuthenticationBackend(object):
@@ -114,7 +114,7 @@ class LDAPAuthenticationBackend(object):
             raise ValueError('Scope value for the LDAP query must be one of '
                              '%s.' % str(SEARCH_SCOPES.keys()))
 
-        self._account_pattern = account_pattern or '{id_attr}={{username}}'.format(id_attr=id_attr or 'uid')
+        self._account_pattern = account_pattern or '{id_attr}={{username}}'.format(id_attr=id_attr or 'uid')  # noqa: E501
         self._group_pattern = group_pattern or USER_GROUP_MEMBERSHIP_QUERY
         self._base_ou = base_ou
         self._scope = SEARCH_SCOPES[scope]

--- a/st2auth_enterprise_ldap_backend/ldap_backend.py
+++ b/st2auth_enterprise_ldap_backend/ldap_backend.py
@@ -62,7 +62,7 @@ class LDAPAuthenticationBackend(object):
     )
 
     def __init__(self, bind_dn, bind_password, base_ou, group_dns, host, port=389,
-                 scope='subtree', id_attr='uid', use_ssl=False, use_tls=False,
+                 scope='subtree', id_attr=None,  use_ssl=False, use_tls=False,
                  cacert=None, network_timeout=10.0, chase_referrals=False, debug=False,
                  client_options=None, group_dns_check='and',
                  cache_user_groups_response=True, cache_user_groups_cache_ttl=120,

--- a/st2auth_enterprise_ldap_backend/ldap_backend.py
+++ b/st2auth_enterprise_ldap_backend/ldap_backend.py
@@ -51,7 +51,7 @@ VALID_GROUP_DNS_CHECK_VALUES = [
 # Note: To avoid injection attacks the final query needs to be assembled ldap.filter.filter_format
 # method and *NOT* by doing simple string formating / concatenation (method ensures filter values
 # are correctly escaped).
-USER_GROUP_MEMBERSHIP_QUERY = '(|(&(objectClass=*)(|(member=%(user_dn)s)(uniqueMember=%(user_dn)s)(memberUid=%(username)s))))'
+USER_GROUP_MEMBERSHIP_QUERY = '(|(&(objectClass=*)(|(member={user_dn})(uniqueMember={user_dn})(memberUid={username}))))'
 
 
 class LDAPAuthenticationBackend(object):
@@ -114,7 +114,7 @@ class LDAPAuthenticationBackend(object):
             raise ValueError('Scope value for the LDAP query must be one of '
                              '%s.' % str(SEARCH_SCOPES.keys()))
 
-        self._account_pattern = account_pattern or '{id_attr}=%s'.format(id_attr=id_attr or 'uid')
+        self._account_pattern = account_pattern or '{id_attr}={{username}}'.format(id_attr=id_attr or 'uid')
         self._group_pattern = group_pattern or USER_GROUP_MEMBERSHIP_QUERY
         self._base_ou = base_ou
         self._scope = SEARCH_SCOPES[scope]
@@ -315,7 +315,7 @@ class LDAPAuthenticationBackend(object):
         :rtype: ``tuple`` (``user_dn``, ``user_info_dict``)
         """
         username = ldap.filter.escape_filter_chars(username)
-        query = self._account_pattern % dict(username=username)
+        query = self._account_pattern.format(username=username)
         result = connection.search_s(self._base_ou, self._scope, query, [])
 
         if result:
@@ -349,7 +349,7 @@ class LDAPAuthenticationBackend(object):
             'user_dn': ldap.filter.escape_filter_chars(user_dn),
             'username': ldap.filter.escape_filter_chars(username),
         }
-        query = self._group_pattern % filter_values
+        query = self._group_pattern.format(**filter_values)
         result = connection.search_s(self._base_ou, self._scope, query, [])
 
         if result:

--- a/st2auth_enterprise_ldap_backend/ldap_backend.py
+++ b/st2auth_enterprise_ldap_backend/ldap_backend.py
@@ -114,7 +114,8 @@ class LDAPAuthenticationBackend(object):
             raise ValueError('Scope value for the LDAP query must be one of '
                              '%s.' % str(SEARCH_SCOPES.keys()))
 
-        self._account_pattern = account_pattern or '{id_attr}={{username}}'.format(id_attr=id_attr or 'uid')  # noqa: E501
+        default_account_pattern = '{id_attr}={{username}}'.format(id_attr=id_attr or 'uid')
+        self._account_pattern = account_pattern or default_account_pattern
         self._group_pattern = group_pattern or USER_GROUP_MEMBERSHIP_QUERY
         self._base_ou = base_ou
         self._scope = SEARCH_SCOPES[scope]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,10 @@
 unittest2
 tox
 mock>=1.0
-pep8>=1.6.0,<1.7
+flake8
 st2flake8==0.1.0
-pylint>=1.4.3,<1.5
+pylint==1.9.5
 nose>=1.3.7
+coverage
+-e git+https://github.com/StackStorm/st2.git#egg=st2auth&subdirectory=st2auth
+-e git+https://github.com/StackStorm/st2.git#egg=st2common&subdirectory=st2common

--- a/tests/unit/test_backend.py
+++ b/tests/unit/test_backend.py
@@ -114,6 +114,25 @@ class LDAPBackendTest(unittest2.TestCase):
 
     @mock.patch.object(
         ldap.ldapobject.SimpleLDAPObject, 'simple_bind_s',
+        mock.MagicMock(return_value=None))
+    @mock.patch.object(
+        ldap.ldapobject.SimpleLDAPObject, 'search_s',
+        mock.MagicMock(side_effect=[LDAP_USER_SEARCH_RESULT, LDAP_GROUP_SEARCH_RESULT]))
+    def test_authenticate_without_password(self):
+        backend = ldap_backend.LDAPAuthenticationBackend(
+            LDAP_BIND_DN,
+            LDAP_BIND_PASSWORD,
+            LDAP_BASE_OU,
+            LDAP_GROUP_DNS,
+            LDAP_HOST,
+            id_attr=LDAP_ID_ATTR
+        )
+
+        with self.assertRaises(ValueError):
+            backend.authenticate(LDAP_USER_UID, '')
+
+    @mock.patch.object(
+        ldap.ldapobject.SimpleLDAPObject, 'simple_bind_s',
         mock.MagicMock(side_effect=Exception()))
     def test_authenticate_failure_bad_bind_cred(self):
         backend = ldap_backend.LDAPAuthenticationBackend(

--- a/tests/unit/test_backend.py
+++ b/tests/unit/test_backend.py
@@ -749,6 +749,25 @@ class LDAPBackendTest(unittest2.TestCase):
         mock.MagicMock(return_value=None))
     @mock.patch.object(
         ldap.ldapobject.SimpleLDAPObject, 'search_s',
+        mock.MagicMock(side_effect=[2 * LDAP_USER_SEARCH_RESULT, LDAP_GROUP_SEARCH_RESULT]))
+    def test_get_user_multiple_results(self):
+        backend = ldap_backend.LDAPAuthenticationBackend(
+            LDAP_BIND_DN,
+            LDAP_BIND_PASSWORD,
+            LDAP_BASE_OU,
+            LDAP_GROUP_DNS,
+            LDAP_HOST,
+            id_attr=LDAP_ID_ATTR
+        )
+
+        user_info = backend.get_user(username=LDAP_USER_UID)
+        self.assertIsNone(user_info)
+
+    @mock.patch.object(
+        ldap.ldapobject.SimpleLDAPObject, 'simple_bind_s',
+        mock.MagicMock(return_value=None))
+    @mock.patch.object(
+        ldap.ldapobject.SimpleLDAPObject, 'search_s',
         mock.MagicMock(side_effect=[LDAP_USER_SEARCH_RESULT, LDAP_GROUP_SEARCH_RESULT]))
     def test_get_user_groups(self):
         backend = ldap_backend.LDAPAuthenticationBackend(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -163,7 +163,21 @@ class LDAPBackendConfigurationTest(unittest2.TestCase):
             id_attr=None
         )
 
-        self.assertEqual('uid', backend._id_attr)
+        self.assertEqual('uid={username}', backend._account_pattern)
+
+    def test_id_attr_and_account_pattern(self):
+        account_pattern = '(|(username={username})(mail={username}))'
+        backend = ldap_backend.LDAPAuthenticationBackend(
+            LDAP_BIND_DN,
+            LDAP_BIND_PASSWORD,
+            LDAP_BASE_OU,
+            LDAP_GROUP_DNS,
+            LDAP_HOST,
+            id_attr='user',
+            account_pattern=account_pattern,
+        )
+
+        self.assertEqual(account_pattern, backend._account_pattern)
 
     def test_both_ssl_tls_true(self):
         self.assertRaises(

--- a/tox.ini
+++ b/tox.ini
@@ -7,5 +7,5 @@ deps = -r{toxinidir}/requirements.txt
 commands = nosetests -sv tests/unit
 
 [testenv:lint]
-commands = flake8 --config ./lint-configs/python/.flake8-proprietary st2auth_enterprise_ldap_backend/
+commands = flake8 --config ./lint-configs/python/.flake8 st2auth_enterprise_ldap_backend/
            pylint -E --rcfile=./lint-configs/python/.pylintrc st2auth_enterprise_ldap_backend/

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,lint
+envlist = py27,py36,lint
 
 [testenv]
 deps = -r{toxinidir}/requirements.txt


### PR DESCRIPTION
In some cases users will need to override the account and group LDAP query patterns, and we previously did not enable this. This PR adds this feature, and it inadvertently fixes a DRY bug regarding the default value of the `id_attr` configuration option.

I had to refactor the `_get_groups_for_user` method a bit, but it converts from using `filter_format`, which just [called `escape_filter_chars`](https://github.com/python-ldap/python-ldap/blob/e885b621562a3c987934be3fba3873d21026bf5c/Lib/ldap/filter.py#L57):

```python
def filter_format(filter_template, assertion_values):
  return filter_template % tuple(escape_filter_chars(v) for v in assertion_values)
```

to using `escape_filter_chars` directly:

```python
filter_values = {
    'user_dn': ldap.filter.escape_filter_chars(user_dn),
    'username': ldap.filter.escape_filter_chars(username),
}
query = self._group_pattern % filter_values
```